### PR TITLE
added callback to set devices for the screen

### DIFF
--- a/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
+++ b/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
@@ -55,7 +55,7 @@ export default function BluetoothScreen({ navigation }: Props): React.ReactEleme
     });
 
     return () => {
-      bleService.stopScanForDevices();
+      bleService.stopScanForDevices(setAllDevices);
     };
   }, []);
 

--- a/app/human-detector-app/src/ble/bleServices.ts
+++ b/app/human-detector-app/src/ble/bleServices.ts
@@ -88,8 +88,9 @@ export class BLEService {
   /**
    * Stop scanning for new devices
    */
-  public stopScanForDevices() {
+  public stopScanForDevices(callback: (devices: Device[]) => void) {
     this.devices = [];
+    callback(this.devices);
     this.bleManager.stopDeviceScan();
   }
 


### PR DESCRIPTION
# Description

Super easy fix to EYE-120.  Had to call the setAllDevices hook in `stopScanForDevices` to update the value of the devices array on the screen.

## Testing

Local testing with the pi I have, the device list is cleared now.

## JIRA Ticket Link

https://eyespycamera.atlassian.net/jira/software/projects/EYE/boards/1?selectedIssue=EYE-120