### PR TITLE
[EYE-134] Sync users to DB on sign-up

### DIFF
--- a/server/cdk/lib/cdk-stack.ts
+++ b/server/cdk/lib/cdk-stack.ts
@@ -144,6 +144,11 @@ export class CdkStack extends cdk.Stack {
       },
       lambdaTriggers: {
         postAuthentication: syncLambda,
+        // HACK: the parameters used in syncLambda are common between the post-auth
+        //       and post-confirm triggers, so we can reuse it here (for now).
+        //       If the post-confirm trigger starts breaking, something probably
+        //       changed and it'll need a dedicated lambda function.
+        postConfirmation: syncLambda,
       },
     });
     const supportedIdentityProviders: cognito.UserPoolClientIdentityProvider[] =


### PR DESCRIPTION
# Description
Users who sign up in the app weren't being synchronized to our database, causing every backend request to reject with `403`. This hacky fix adds a post-confirmation trigger, reusing the sync lambda meant for a post-auth event.

# Testing
Signing up in the app and adding/deleting groups works as expected now.