### PR TITLE
[EYE-141] Fix Google login

### DIFF
--- a/server/cdk/lib/cdk-stack.ts
+++ b/server/cdk/lib/cdk-stack.ts
@@ -155,6 +155,10 @@ export class CdkStack extends cdk.Stack {
       [cognito.UserPoolClientIdentityProvider.COGNITO];
     if (config.auth?.google !== undefined) {
       new cognito.UserPoolIdentityProviderGoogle(this, "GoogleIDP", {
+        attributeMapping: {
+          email: cognito.ProviderAttribute.GOOGLE_EMAIL,
+        },
+        scopes: ["profile", "email", "openid"],
         clientId: config.auth.google.clientId,
         clientSecretValue: cdk.SecretValue.unsafePlainText(
           config.auth.google.clientSecret


### PR DESCRIPTION
# Description
Login with Google previously wasn't synchronizing to our DB, and login broke completely after adding email as a required attribute. This PR maps the email of Google users to Cognito's required `email` attribute, which fixes login. #80 seems to have also fixed the sync issues with Google login as well.

# Testing
Signing in for the first time with my Google account worked, and I was able to create and delete groups as usual.